### PR TITLE
Improve link styling

### DIFF
--- a/_sass/0-settings/_mixins.scss
+++ b/_sass/0-settings/_mixins.scss
@@ -24,3 +24,10 @@
   width: 1px;
   word-wrap: normal !important;
 }
+
+@mixin undecorated-link() {
+  text-decoration: none;
+  &:hover {
+    text-decoration: underline;
+  }
+}

--- a/_sass/2-base/_base.scss
+++ b/_sass/2-base/_base.scss
@@ -154,11 +154,11 @@ img,
 }
 
 a {
-  text-decoration: none;
   color: $text-color;
   transition: $global-transition;
   &:hover {
       color: $brand-color;
+      text-decoration: underline;
   }
 }
 

--- a/_sass/3-modules/_footer.scss
+++ b/_sass/3-modules/_footer.scss
@@ -70,6 +70,7 @@
   .nav__link {
     font-size: 16px;
     color: $black;
+    @include undecorated-link();
   }
   @media only screen and (max-width: $desktop) {
     padding-right: 0;
@@ -146,5 +147,6 @@
   color: rgba($black, .6);
   a {
     color: $black;
+    @include undecorated-link();
   }
 }

--- a/_sass/3-modules/_header.scss
+++ b/_sass/3-modules/_header.scss
@@ -107,8 +107,8 @@
         position: relative;
         font-size: 16px;
         font-weight: 400;
-        text-decoration: none;
         color: $black;
+        @include undecorated-link();
         &:hover {
           &::before {
             opacity: 1;
@@ -153,6 +153,7 @@
         position: relative;
         font-size: 18px;
         color: $text-color;
+        @include undecorated-link();
       }
 
       @media only screen and (max-width: $mobile) {

--- a/_sass/3-modules/_social-links.scss
+++ b/_sass/3-modules/_social-links.scss
@@ -31,6 +31,7 @@
     &:hover {
       background-color: $brand-color;
     }
+    @include undecorated-link();
   }
 
   @media only screen and (max-width: $desktop) {

--- a/_sass/4-layouts/_home-page.scss
+++ b/_sass/4-layouts/_home-page.scss
@@ -58,6 +58,7 @@
   font-size: 32px;
   a {
     color: $white;
+    @include undecorated-link();
   }
   @media only screen and (max-width: $mobile) {
     margin: 5px 0 10px;

--- a/_sass/4-layouts/_post.scss
+++ b/_sass/4-layouts/_post.scss
@@ -41,6 +41,7 @@
     margin-right: 5px;
     margin-bottom: 5px;
     padding: 0 10px;
+    @include undecorated-link();
     text-transform: uppercase;
     font-family: 'Poppins', Arial, sans-serif;
     font-size: 10px;


### PR DESCRIPTION
By default, links should have an underline.
Very hard to notice it's a link otherwise.

Add an 'undecorated-link' mixin for things like
nav links that only have an underline on hover.