### PR TITLE
Supprt 'unlink' question to remove bikebuses

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ Images on the Jotform are downloaded and re-hosted in this repo (as compressed w
 Note that the images are checked in, because we may need to delete Jotform reponses,
 which would delete the uploaded images.
 
+The form has an 'unlist' question; if the answer is non-empty,
+the bus is not listed on the website any longer.
+
 ## Original Theme
 
 This site originally used the Aditu theme. It's been customized heavily but referring to the original

--- a/_data/buses.yml
+++ b/_data/buses.yml
@@ -12,6 +12,7 @@
 # email: mybikebus@gmail.com
 # instagram: mybikebus
 # bluesky: mybikebus
+# unlist: If true, hide this bike bus. Generally used for the dynamic form data, to remove a school
 - name: Alameda
   email: CoachBalto@gmail.com
   slug: alameda

--- a/_plugins/bus_site_generator.rb
+++ b/_plugins/bus_site_generator.rb
@@ -14,6 +14,7 @@ module Bikebuspdx
     def generate(site)
       rows = fetch_webhookdb_rows
       merged = merge_data(site.data.fetch('buses'), rows)
+      merged.delete_if { |h| (h['unlist'] || '').length > 0 }
       merged.each { |h| rehost_images(h) }
       site.data['buses'] = merged
       dir = '_pages/buses'
@@ -137,13 +138,14 @@ module Bikebuspdx
                 WHEN questions->>'school' != '' THEN questions->>'school'
                 ELSE questions->>'schooltext' END
                 AS name,
-            questions->'maintext' as content,
-            questions->'websitelabel' as link_text,
-            questions->'websitelink' as link_href,
+            questions->>'maintext' as content,
+            questions->>'websitelabel' as link_text,
+            questions->>'websitelink' as link_href,
             questions->'headerimage'->>0 as image,
             questions->'image1'->>0 as map_image,
             questions->'image2'->>0 as map_image2,
-            questions->'routemaplink' as map_href,
+            questions->>'routemaplink' as map_href,
+            questions->>'unlist' as unlist,
             questions->>'bluesky' as bluesky,
             questions->>'instagram' as instagram
         FROM #{webhookdb_table}


### PR DESCRIPTION
The form has an 'unlist' question; if the answer is non-empty, the bus is not listed on the website any longer.